### PR TITLE
Increase max buffer for stdio

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ function zip (inPath, outPath, cb) {
   }
 
   function doZip2 () {
-    cp.exec(getZipCommand(inPath, outPath), function (err) {
+    cp.exec(getZipCommand(inPath, outPath), { maxBuffer: Infinity }, function (err) {
       cb(err)
     })
   }
@@ -85,7 +85,7 @@ function getZipCommand (inPath, outPath) {
 
 function unzip (inPath, outPath, cb) {
   if (!cb) cb = function () {}
-  cp.exec(getUnzipCommand(inPath, outPath), function (err) {
+  cp.exec(getUnzipCommand(inPath, outPath), { maxBuffer: Infinity }, function (err) {
     cb(err)
   })
 }


### PR DESCRIPTION
Prevents async zip from crashing on large directories

I would like to do the same for sync version of these calls, but libuv explodes: https://github.com/nodejs/node/issues/8096

Alternatively these could be switched to `child_process.spawn` with `stdio: 'ignore'` which would essentially pipe all stdio to `/dev/null` instead of buffering it all in memory.
