### PR TITLE
fix(windows): quote paths for powershell

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,14 +114,18 @@ function getUnzipCommand () {
   }
 }
 
+function quotePath (pathToTransform) {
+  return '"' + pathToTransform + '"'
+}
+
 function getZipArgs (inPath, outPath) {
   if (process.platform === 'win32') {
     return [
       '-nologo',
       '-noprofile',
       '-command', '& { param([String]$myInPath, [String]$myOutPath); Add-Type -A "System.IO.Compression.FileSystem"; [IO.Compression.ZipFile]::CreateFromDirectory($myInPath, $myOutPath); }',
-      '-myInPath', inPath,
-      '-myOutPath', outPath
+      '-myInPath', quotePath(inPath),
+      '-myOutPath', quotePath(outPath)
     ]
   } else {
     var fileName = path.basename(inPath)
@@ -135,8 +139,8 @@ function getUnzipArgs (inPath, outPath) {
       '-nologo',
       '-noprofile',
       '-command', '& { param([String]$myInPath, [String]$myOutPath); Add-Type -A "System.IO.Compression.FileSystem"; [IO.Compression.ZipFile]::ExtractToDirectory($myInPath, $myOutPath); }',
-      '-myInPath', inPath,
-      '-myOutPath', outPath
+      '-myInPath', quotePath(inPath),
+      '-myOutPath', quotePath(outPath)
     ]
   } else {
     return ['-o', inPath, '-d', outPath]

--- a/test/unzip.js
+++ b/test/unzip.js
@@ -40,3 +40,26 @@ test('unzip', function (t) {
     })
   })
 })
+
+test('unzip from a folder with a space in it', function (t) {
+  t.plan(4)
+
+  var zipSpacePath = path.join(tmpPath, 'folder space', path.basename(fileZipPath))
+  mkdirp.sync(path.dirname(zipSpacePath))
+  fs.copyFileSync(fileZipPath, zipSpacePath)
+
+  var tmpFilePath = path.join(tmpPath, 'file.txt')
+  rimraf(tmpFilePath, function (err) {
+    t.error(err)
+
+    zip.unzip(zipSpacePath, tmpPath, function (err) {
+      t.error(err)
+
+      t.ok(fs.existsSync(tmpFilePath), 'extracted file should exist')
+      var tmpFile = fs.readFileSync(tmpFilePath)
+      var file = fs.readFileSync(filePath)
+
+      t.deepEqual(tmpFile, file)
+    })
+  })
+})


### PR DESCRIPTION
Fixes #23.

This will merge conflict with #22, although I recommend merging that one first (along with #21).