### PR TITLE
Remove rimraf

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ var cp = require('child_process')
 var fs = require('fs')
 var os = require('os')
 var path = require('path')
-var rimraf = require('rimraf')
 
 function zip (inPath, outPath, cb) {
   if (!cb) cb = function () {}
@@ -47,7 +46,7 @@ function zip (inPath, outPath, cb) {
   // Windows zip command does not overwrite existing files. So do it manually first.
   function doZip () {
     if (process.platform === 'win32') {
-      rimraf(outPath, doZip2)
+      fs.rmdir(outPath, { recursive: true, maxRetries: 3 }, doZip2)
     } else {
       doZip2()
     }
@@ -73,7 +72,7 @@ function zipSync (inPath, outPath) {
       fs.writeFileSync(path.join(tmpPath, path.basename(inPath)), inFile)
       inPath = tmpPath
     }
-    rimraf.sync(outPath)
+    fs.rmdirSync(outPath, { recursive: true, maxRetries: 3 })
   }
   var opts = {
     cwd: path.dirname(inPath),

--- a/package.json
+++ b/package.json
@@ -34,9 +34,6 @@
   "scripts": {
     "test": "standard && tape test/*.js"
   },
-  "dependencies": {
-    "rimraf": "^3.0.0"
-  },
   "funding": [
     {
       "type": "github",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
   "scripts": {
     "test": "standard && tape test/*.js"
   },
+  "engines": {
+    "node": ">=12.10"
+  },
   "funding": [
     {
       "type": "github",

--- a/test/unzip.js
+++ b/test/unzip.js
@@ -1,6 +1,5 @@
 var fs = require('fs')
 var path = require('path')
-var rimraf = require('rimraf')
 var test = require('tape')
 var zip = require('../')
 
@@ -12,7 +11,7 @@ fs.mkdirSync(tmpPath, { recursive: true })
 
 test('unzipSync', function (t) {
   var tmpFilePath = path.join(tmpPath, 'file.txt')
-  rimraf.sync(tmpFilePath)
+  fs.rmdirSync(tmpFilePath, { recursive: true })
   zip.unzipSync(fileZipPath, tmpPath)
 
   var tmpFile = fs.readFileSync(tmpFilePath)
@@ -26,7 +25,7 @@ test('unzip', function (t) {
   t.plan(3)
 
   var tmpFilePath = path.join(tmpPath, 'file.txt')
-  rimraf(tmpFilePath, function (err) {
+  fs.rmdir(tmpFilePath, { recursive: true }, function (err) {
     t.error(err)
 
     zip.unzip(fileZipPath, tmpPath, function (err) {
@@ -48,7 +47,7 @@ test('unzip from a folder with a space in it', function (t) {
   fs.copyFileSync(fileZipPath, zipSpacePath)
 
   var tmpFilePath = path.join(tmpPath, 'file.txt')
-  rimraf(tmpFilePath, function (err) {
+  fs.rmdir(tmpFilePath, { recursive: true }, function (err) {
     t.error(err)
 
     zip.unzip(zipSpacePath, tmpPath, function (err) {

--- a/test/zip.js
+++ b/test/zip.js
@@ -1,6 +1,5 @@
 var fs = require('fs')
 var path = require('path')
-var rimraf = require('rimraf')
 var test = require('tape')
 var zip = require('../')
 
@@ -14,7 +13,7 @@ test('zipSync', function (t) {
   zip.zipSync(filePath, tmpFileZipPath)
 
   var tmpFilePath = path.join(tmpPath, 'file.txt')
-  rimraf.sync(tmpFilePath)
+  fs.rmdirSync(tmpFilePath, { recursive: true })
   zip.unzipSync(tmpFileZipPath, tmpPath)
 
   var tmpFile = fs.readFileSync(tmpFilePath)
@@ -32,7 +31,7 @@ test('zip', function (t) {
     t.error(err)
 
     var tmpFilePath = path.join(tmpPath, 'file.txt')
-    rimraf(tmpFilePath, function (err) {
+    fs.rmdir(tmpFilePath, { recursive: true }, function (err) {
       t.error(err)
 
       zip.unzip(tmpFileZipPath, tmpPath, function (err) {


### PR DESCRIPTION
In the spirit of shedding dependencies, I've removed `rimraf` with the `recursive` option of `fs.rmdir` which was added in Node.js 12.10 and which is now the active LTS. I'm opening this PR in case you're interested in merging this now or later when v10 reaches EOL next year.

Just to be safe, this sets `maxRetries` to 3 in the user-facing code, because that was the default value used by rimraf.

Thanks for cross-zip!