### PR TITLE
Fix DEP0147 DeprecationWarning

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ function zip (inPath, outPath, cb) {
   // Windows zip command does not overwrite existing files. So do it manually first.
   function doZip () {
     if (process.platform === 'win32') {
-      fs.rmdir(outPath, { recursive: true, maxRetries: 3 }, doZip2)
+      fs.rm(outPath, { recursive: true, maxRetries: 3 }, doZip2)
     } else {
       doZip2()
     }
@@ -72,7 +72,7 @@ function zipSync (inPath, outPath) {
       fs.writeFileSync(path.join(tmpPath, path.basename(inPath)), inFile)
       inPath = tmpPath
     }
-    fs.rmdirSync(outPath, { recursive: true, maxRetries: 3 })
+    fs.rmSync(outPath, { recursive: true, maxRetries: 3 })
   }
   var opts = {
     cwd: path.dirname(inPath),

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test": "standard && tape test/*.js"
   },
   "engines": {
-    "node": ">=12.10"
+    "node": ">=14.14"
   },
   "funding": [
     {

--- a/test/unzip.js
+++ b/test/unzip.js
@@ -11,7 +11,7 @@ fs.mkdirSync(tmpPath, { recursive: true })
 
 test('unzipSync', function (t) {
   var tmpFilePath = path.join(tmpPath, 'file.txt')
-  fs.rmdirSync(tmpFilePath, { recursive: true })
+  fs.rmSync(tmpFilePath, { recursive: true })
   zip.unzipSync(fileZipPath, tmpPath)
 
   var tmpFile = fs.readFileSync(tmpFilePath)
@@ -25,7 +25,7 @@ test('unzip', function (t) {
   t.plan(3)
 
   var tmpFilePath = path.join(tmpPath, 'file.txt')
-  fs.rmdir(tmpFilePath, { recursive: true }, function (err) {
+  fs.rm(tmpFilePath, { recursive: true }, function (err) {
     t.error(err)
 
     zip.unzip(fileZipPath, tmpPath, function (err) {
@@ -47,7 +47,7 @@ test('unzip from a folder with a space in it', function (t) {
   fs.copyFileSync(fileZipPath, zipSpacePath)
 
   var tmpFilePath = path.join(tmpPath, 'file.txt')
-  fs.rmdir(tmpFilePath, { recursive: true }, function (err) {
+  fs.rm(tmpFilePath, { recursive: true }, function (err) {
     t.error(err)
 
     zip.unzip(zipSpacePath, tmpPath, function (err) {

--- a/test/zip.js
+++ b/test/zip.js
@@ -13,7 +13,7 @@ test('zipSync', function (t) {
   zip.zipSync(filePath, tmpFileZipPath)
 
   var tmpFilePath = path.join(tmpPath, 'file.txt')
-  fs.rmdirSync(tmpFilePath, { recursive: true })
+  fs.rmSync(tmpFilePath, { recursive: true })
   zip.unzipSync(tmpFileZipPath, tmpPath)
 
   var tmpFile = fs.readFileSync(tmpFilePath)
@@ -31,7 +31,7 @@ test('zip', function (t) {
     t.error(err)
 
     var tmpFilePath = path.join(tmpPath, 'file.txt')
-    fs.rmdir(tmpFilePath, { recursive: true }, function (err) {
+    fs.rm(tmpFilePath, { recursive: true }, function (err) {
       t.error(err)
 
       zip.unzip(tmpFileZipPath, tmpPath, function (err) {


### PR DESCRIPTION
Fixes this deprecation warning:

> [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead

https://nodejs.org/api/deprecations.html#DEP0147

Not available in Node.js v12 so I bumped the engine requirement.