### PR TITLE
fix: ensure zip files use foward slashes on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ function getZipArgs (inPath, outPath) {
     return [
       '-nologo',
       '-noprofile',
-      '-command', '& { param([String]$myInPath, [String]$myOutPath); Add-Type -A "System.IO.Compression.FileSystem"; [IO.Compression.ZipFile]::CreateFromDirectory($myInPath, $myOutPath); exit !$? }',
+      '-command', '& { param([String]$myInPath, [String]$myOutPath); Add-Type -A "System.IO.Compression.FileSystem"; [System.AppContext]::SetSwitch("Switch.System.IO.Compression.ZipFile.UseBackslash", $false); [IO.Compression.ZipFile]::CreateFromDirectory($myInPath, $myOutPath); exit !$? }',
       '-myInPath', quotePath(inPath),
       '-myOutPath', quotePath(outPath)
     ]

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "url": "https://github.com/feross/cross-zip/issues"
   },
   "devDependencies": {
+    "node-stream-zip": "^1.15.0",
     "standard": "*",
     "tape": "^5.0.0"
   },

--- a/test/zip.js
+++ b/test/zip.js
@@ -1,4 +1,5 @@
 var fs = require('fs')
+var StreamZip = require('node-stream-zip')
 var path = require('path')
 var test = require('tape')
 var zip = require('../')
@@ -42,6 +43,28 @@ test('zip', function (t) {
 
         t.deepEqual(tmpFile, file)
       })
+    })
+  })
+})
+
+test('zip slash compatibility', function (t) {
+  t.plan(3)
+
+  var tmpFileZipPath = path.join(tmpPath, 'subdir.zip')
+  zip.zip(path.join(__dirname, 'content'), tmpFileZipPath, function (err) {
+    t.error(err)
+
+    var archive = new StreamZip({
+      file: tmpFileZipPath,
+      storeEntries: true,
+      skipEntryNameValidation: true
+    })
+
+    archive.on('ready', function (err) {
+      t.error(err)
+
+      // Specifically testing that this is subdir/sub.txt and NOT subdir\sub.txt on windows
+      t.deepEquals(Object.keys(archive.entries()), ['file.txt', 'file.txt.zip', 'subdir/sub.txt'])
     })
   })
 })


### PR DESCRIPTION
The added test should tell the story here.  Basically on windows powershell does this annoying thing where usage of `System.IO.Compression` by default preserves backslashes in zip entry names...  Instead of doing the sensible thing and using forward slashes so the zip files actually work across platforms.

This sets the flag (that is on by default in newer versions of .NET) to enable this behavior.